### PR TITLE
Support yajs.vim syntax group names

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -33,13 +33,13 @@ set cpo&vim
 " ============
 
 " Regex of syntax group names that are or delimit string or are comments.
-let s:syng_strcom = 'javaScript\%(String\|RegexpString\|CommentTodo\|LineComment\|Comment\|DocComment\)'
+let s:syng_strcom = 'java[sS]cript\%(String\|RegexpString\|CommentTodo\|LineComment\|Comment\|DocComment\)'
 
 " Regex of syntax group names that are strings.
-let s:syng_string = 'javaScript\%(RegexpString\)'
+let s:syng_string = 'java[sS]cript\%(RegexpString\)'
 
 " Regex of syntax group names that are strings or documentation.
-let s:syng_multiline = 'javaScriptDocComment\|javaScriptComment'
+let s:syng_multiline = 'java[sS]criptDocComment\|java[sS]criptComment'
 
 " Expression used to check whether we should skip a match with searchpair().
 let s:skip_expr = "synIDattr(synID(line('.'),col('.'),1),'name') =~ '".s:syng_strcom."'"


### PR DESCRIPTION
yajs.vim uses all-lowercase `javascript` prefix
